### PR TITLE
#2 Update TeamsLoggerHandler

### DIFF
--- a/src/Logging/TeamsLoggerHandler.php
+++ b/src/Logging/TeamsLoggerHandler.php
@@ -13,6 +13,8 @@ class TeamsLoggerHandler extends AbstractProcessingHandler
 
     public $url;
 
+    protected $teamsNotification;
+
     public function __construct($url, $level = Logger::DEBUG)
     {
         parent::__construct($level);


### PR DESCRIPTION
Add this property definition for $teamsNotification to the class.

This prevents a "DEPRECATED  Creation of dynamic property..." warning.