### PR TITLE
Enabling Optional - Verify SSL on Guzzle

### DIFF
--- a/config/teams.php
+++ b/config/teams.php
@@ -2,4 +2,5 @@
 
 return [
     'webhook_url' => env('TEAMS_WEBHOOK_URL'),
+    'verify_ssl' => true,
 ];

--- a/src/TeamsNotification.php
+++ b/src/TeamsNotification.php
@@ -24,7 +24,9 @@ class TeamsNotification
     public function __construct($webhookUrl = null)
     {
         $this->webhookUrl = $webhookUrl ?: config('teams.webhook_url');
-        $this->client = new Client(); // Initialize Guzzle client
+        $this->client = new Client([
+            'verify' => config('teams.verify_ssl', true)
+        ]); // Initialize Guzzle client
     }
 
     // Method to set the color and allow chaining


### PR DESCRIPTION
Adding the capacity to not verify SSL will enable users with reversed proxied servers can send messages without the cUrl error 60.